### PR TITLE
minor fix: changed `display` and `text-align` to `align`

### DIFF
--- a/components/slides/auth-page.ftd
+++ b/components/slides/auth-page.ftd
@@ -68,7 +68,7 @@ padding.px: 10
 -- ds.copy-regular: 
 text: $lang.create-account
 text if { page.signin-url }: $lang.existing-account
-display: inline
+align: inline
 
 -- ftd.text: $lang.signin-type
 text if { page.signin-url }: $lang.signup-type

--- a/components/slides/full-page.ftd
+++ b/components/slides/full-page.ftd
@@ -54,7 +54,7 @@ spacing.fixed.px: 8
 
 -- ds.copy-regular: 
 text: Team:
-display: inline
+align: inline
 
 -- ftd.row:
 spacing.fixed.px: 4

--- a/pages/university/home.ftd
+++ b/pages/university/home.ftd
@@ -16,7 +16,7 @@ module user-data: user-data
 product: $lang.university
 
 -- ds.heading-medium: $lang.university-title
-text-align: center
+align: center
 
 
 -- ftd.row:


### PR DESCRIPTION
Renamed `display` and `text-align` properties to `align` in the `ds.copy-regular` and `ds.heading-medium` component