### PR TITLE
Added help_requested, public_history and public_source to site setting page

### DIFF
--- a/actions/sites/settings/basic.ftd
+++ b/actions/sites/settings/basic.ftd
@@ -30,6 +30,7 @@ js: $assets.files.assets.functions.js
 callAlert("renaming privacy: " + site_slug + ", is_public: " + is_public)
 
 
+
 -- optional string update-editable-error:
 
 -- void update-editable(site_slug, is_editable):
@@ -38,6 +39,41 @@ boolean is_editable:
 js: $assets.files.assets.functions.js
 
 callAlert("update-editable: " + site_slug + ", is_editable: " + is_editable)
+
+
+
+-- optional string update-help-requested-error:
+
+-- void update-help-requested(site_slug, help_requested):
+string site_slug:
+boolean help_requested:
+js: $assets.files.assets.functions.js
+
+callAlert("update-help-requested: " + site_slug + ", help_requested: " + help_requested)
+
+
+
+
+-- optional string update-public-history-error:
+
+-- void update-public-history(site_slug, public_history):
+string site_slug:
+boolean public_history:
+js: $assets.files.assets.functions.js
+
+callAlert("update-public-history: " + site_slug + ", public_history: " + public_history)
+
+
+
+-- optional string update-public-source-error:
+
+-- void update-public-source(site_slug, public_source):
+string site_slug:
+boolean public_source:
+js: $assets.files.assets.functions.js
+
+callAlert("update-public-source: " + site_slug + ", public_source: " + public_source)
+
 
 
 -- optional string mark-package-error:

--- a/pages/sites/setting/index.ftd
+++ b/pages/sites/setting/index.ftd
@@ -123,43 +123,8 @@ dashboard-url: $page.dashboard-url
         radius: curved
         $on-click$: $page.setting-actions.update-help-requested(site_slug=$page.site.site-slug, help_requested=true)
 
-        ;; ------------------------------- public-history -----------------------------------------------
-        -- ds.heading-medium: Site: Public History Enabled
-        if: { page.site.public-history }
-
-        -- ds.copy-regular:
-        if: { page.site.public-history }
-
-        By default sites on FifthTry disables **public history** but you, or someone in your team, enabled public-history
-        on this site. This means that you have given permission to everyone to view the history of this site.
-
-        -- ds.danger-button: Disable Public History
-        if: { page.site.public-history }
-        width: wide
-        radius: curved
-        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=false)
-
-
-
-        -- ds.heading-medium: Site: Public History Disabled
-        if: { !page.site.public-history }
-
-        -- ds.copy-regular:
-        if: { !page.site.public-history }
-
-        The site disabled **public history**. You would enable public-history to the site if you plan to give permission
-        to everyone to view the history of this site.
-
-
-        -- ds.danger-button: Enable Public History
-        if: { !page.site.public-history }
-        width: wide
-        radius: curved
-        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=true)
-
-
         ;; ------------------------------- public-source -----------------------------------------------
-        -- ds.heading-medium: Site: Public Source Enabled
+        -- ds.heading-medium: Source Is Visible To The World
         if: { page.site.public-source }
 
         -- ds.copy-regular:
@@ -169,7 +134,7 @@ dashboard-url: $page.dashboard-url
         on this site. This means that you have given permission to everyone to view the source of this site but they
         cannot edit the content of the site.
 
-        -- ds.danger-button: Disable Public Source
+        -- ds.danger-button: Make Source Private
         if: { page.site.public-source }
         width: wide
         radius: curved
@@ -177,7 +142,7 @@ dashboard-url: $page.dashboard-url
 
 
 
-        -- ds.heading-medium: Site: Public Source Disabled
+        -- ds.heading-medium: Source Is Private
         if: { !page.site.public-source }
 
         -- ds.copy-regular:
@@ -187,11 +152,57 @@ dashboard-url: $page.dashboard-url
         to everyone to view the source of this site but they cannot edit the content of the site.
 
 
-        -- ds.danger-button: Enable Public Source
+        -- ds.danger-button: Make Source Public
         if: { !page.site.public-source }
         width: wide
         radius: curved
         $on-click$: $page.setting-actions.update-public-source(site_slug=$page.site.site-slug, public_source=true)
+
+
+
+        ;; ------------------------------- public-history -----------------------------------------------
+        -- ds.heading-medium: History Is Visible To The World
+        if: { page.site.public-history && page.site.public-source }
+
+        -- ds.copy-regular:
+        if: { page.site.public-history && page.site.public-source }
+
+        By default sites on FifthTry disables **public history** but you, or someone in your team, enabled public-history
+        on this site. This means that you have given permission to everyone to view the history of this site.
+
+        -- ds.heading-medium: History Will Be Visible To The World If Source Becomes Public
+        if: { page.site.public-history && !page.site.public-source }
+
+        -- ds.copy-regular:
+        if: { page.site.public-history && !page.site.public-source }
+
+        By default sites on FifthTry disables **public history** but you, or someone in your team, enabled public-history
+        on this site. This means that you have given permission to everyone to view the history of this site as soon as
+        you enable public-source. Currently public-source is disabled, so public-history is also disabled.
+
+        -- ds.danger-button: Make History Private
+        if: { page.site.public-history }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=false)
+
+
+
+        -- ds.heading-medium: History Is Private
+        if: { !page.site.public-history && page.site.public-source }
+
+        -- ds.copy-regular:
+        if: { !page.site.public-history && page.site.public-source }
+
+        The site disabled **public history**. You would enable public-history to the site if you plan to give permission
+        to everyone to view the history of this site.
+
+
+        -- ds.danger-button: Make History Public
+        if: { !page.site.public-history && page.site.public-source }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=true)
 
 		;; ------------------------------- is-package -----------------------------------------------
 		;;

--- a/pages/sites/setting/index.ftd
+++ b/pages/sites/setting/index.ftd
@@ -85,8 +85,114 @@ dashboard-url: $page.dashboard-url
 		width: wide
 		radius: curved
 		$on-click$: $page.setting-actions.update-editable(site_slug=$page.site.site-slug, is_editable=true)
-		
-		
+
+
+		;; ------------------------------- help-requested -----------------------------------------------
+        -- ds.heading-medium: Site: Help Requested Enabled
+        if: { page.site.help-requested }
+
+        -- ds.copy-regular:
+        if: { page.site.help-requested }
+
+        By default sites on FifthTry disables **help requested** but you, or someone in your team, enabled help-requested
+        on this site. This means that you have given permission to FifthTry staff members to view the history of this
+        site, view the source of this site and can edit the content of the site.
+
+        -- ds.danger-button: Disable Help Requested
+        if: { page.site.help-requested }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-help-requested(site_slug=$page.site.site-slug, help_requested=false)
+
+
+
+        -- ds.heading-medium: Site: Help Requested Disabled
+        if: { !page.site.help-requested }
+
+        -- ds.copy-regular:
+        if: { !page.site.help-requested }
+
+        The site disabled **help requested**. You would enable help-requested to the site if you plan to give permission
+        to FifthTry staff members to view the history of this site, view the source of this site and can edit the
+        content of the site.
+
+
+        -- ds.danger-button: Enable Help Requested
+        if: { !page.site.help-requested }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-help-requested(site_slug=$page.site.site-slug, help_requested=true)
+
+        ;; ------------------------------- public-history -----------------------------------------------
+        -- ds.heading-medium: Site: Public History Enabled
+        if: { page.site.public-history }
+
+        -- ds.copy-regular:
+        if: { page.site.public-history }
+
+        By default sites on FifthTry disables **public history** but you, or someone in your team, enabled public-history
+        on this site. This means that you have given permission to everyone to view the history of this site.
+
+        -- ds.danger-button: Disable Public History
+        if: { page.site.public-history }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=false)
+
+
+
+        -- ds.heading-medium: Site: Public History Disabled
+        if: { !page.site.public-history }
+
+        -- ds.copy-regular:
+        if: { !page.site.public-history }
+
+        The site disabled **public history**. You would enable public-history to the site if you plan to give permission
+        to everyone to view the history of this site.
+
+
+        -- ds.danger-button: Enable Public History
+        if: { !page.site.public-history }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-history(site_slug=$page.site.site-slug, public_history=true)
+
+
+        ;; ------------------------------- public-source -----------------------------------------------
+        -- ds.heading-medium: Site: Public Source Enabled
+        if: { page.site.public-source }
+
+        -- ds.copy-regular:
+        if: { page.site.public-source }
+
+        By default sites on FifthTry disables **public source** but you, or someone in your team, enabled public-source
+        on this site. This means that you have given permission to everyone to view the source of this site but they
+        cannot edit the content of the site.
+
+        -- ds.danger-button: Disable Public Source
+        if: { page.site.public-source }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-source(site_slug=$page.site.site-slug, public_source=false)
+
+
+
+        -- ds.heading-medium: Site: Public Source Disabled
+        if: { !page.site.public-source }
+
+        -- ds.copy-regular:
+        if: { !page.site.public-source }
+
+        The site disabled **public source**. You would enable public-source to the site if you plan to give permission
+        to everyone to view the source of this site but they cannot edit the content of the site.
+
+
+        -- ds.danger-button: Enable Public Source
+        if: { !page.site.public-source }
+        width: wide
+        radius: curved
+        $on-click$: $page.setting-actions.update-public-source(site_slug=$page.site.site-slug, public_source=true)
+
 		;; ------------------------------- is-package -----------------------------------------------
 		;;
 		;; TODO: move this to a separate page, maybe "Developer Settings"

--- a/records/sites.ftd
+++ b/records/sites.ftd
@@ -19,6 +19,9 @@ optional string zip-download-url:
 boolean is-public:
 boolean is-package:
 boolean is-editable:
+boolean help-requested:
+boolean public-history:
+boolean public-source:
 
 
 


### PR DESCRIPTION
Checkout https://github.com/FifthTry/dotcom/pull/154/ for more detail

# Help Requested Disabled

## Public Source and Public History
![127 0 0 1_bb_setting_](https://github.com/user-attachments/assets/0c29fad8-77d0-4cf3-bb7a-7dc1bb8115ae)

## Private Source and Public History
![127 0 0 1_bb_setting_ (1)](https://github.com/user-attachments/assets/ca9823d0-80f4-40e3-8ce2-a70a8eed24d7)

## Private Source and Private History
![127 0 0 1_bb_setting_ (2)](https://github.com/user-attachments/assets/1796bfe6-ad19-4f01-bec5-8be52a6cadfe)

## Public Source and Private History
![127 0 0 1_bb_setting_ (2)](https://github.com/user-attachments/assets/1796bfe6-ad19-4f01-bec5-8be52a6cadfe)

# Help Requested Enabled

![127 0 0 1_bb_setting_ (4)](https://github.com/user-attachments/assets/75d10a6b-f6e7-4ff9-a21e-d4f302fd02de)



