### PR TITLE
Fix: `ftd.string-field` in create-site in mobile ui

### DIFF
--- a/.fastn/config.json
+++ b/.fastn/config.json
@@ -2089,8 +2089,8 @@
         },
         "components/card.ftd": {
           "name": "components/card.ftd",
-          "checksum": "FC1991D3D91ED17DDBF8684CD1A9B9E2D53A91081E8C17F4C089C79B21414DB5",
-          "size": 2372
+          "checksum": "BBC398744BA1E3AE2B53212BAF0977C020DD18F66A05A0F1406B974903F2DA32",
+          "size": 2404
         },
         "components/carousel.ftd": {
           "name": "components/carousel.ftd",
@@ -2246,11 +2246,6 @@
           "name": "components/slider.ftd",
           "checksum": "401307F60806B37AA0AF55CE20554C5D417B6690FAB75C33CD923AC8EA40C35D",
           "size": 2912
-        },
-        "components/storybook.ftd": {
-          "name": "components/storybook.ftd",
-          "checksum": "EC403FF81514CCEEC9F8AEE4C311218AC1E7D3953B4704D4BF410362E0DDDB6B",
-          "size": 2924
         },
         "components/tab-button.ftd": {
           "name": "components/tab-button.ftd",
@@ -2408,8 +2403,8 @@
           "size": 78
         }
       },
-      "zip_url": "https://github.com/fastn-community/design-system/archive/6bef5e00e34c62fda7001a3181102a76606df07b.zip",
-      "checksum": "BB06252CCAB28CC75DE79DD5AE290DBAD75D3D448735DE4649D25B22E37DBD9C"
+      "zip_url": "https://github.com/fastn-community/design-system/archive/16306e142d0ce18c1629958d016727ef6454ca56.zip",
+      "checksum": "CB3E718CA1B087F4E85A78D37B41BCE1DD6B4AE9625EB744381E15D463D9DA68"
     },
     "fastn-community.github.io/doc-site": {
       "files": {

--- a/actions/user/create-site-action.ftd
+++ b/actions/user/create-site-action.ftd
@@ -3,7 +3,7 @@
 
 -- void submit(username, site_slug):
 string username:
-string site_slug:
+ftd.string-field site_slug:
 js: $assets.files.assets.functions.js
 
 callAlert("creating site: " + site_slug + ", under org: " + username)

--- a/components/sites/create-site.ftd
+++ b/components/sites/create-site.ftd
@@ -150,7 +150,7 @@ string dashboard-url:
 				-- ds.primary-button: Create Site
 				width: full
 				radius: curved
-				$on-click$: $create-site.create-site-action.submit(org_slash_username = $create-site.org-slash-username, $site_slug = $create-site.create-site-action.site-slug.value)
+				$on-click$: $create-site.create-site-action.submit(org_slash_username = $create-site.org-slash-username, $site_slug = $create-site.create-site-action.site-slug)
 				
 				-- ds.secondary-button: Cancel
 				width: full


### PR DESCRIPTION
Usage of `ftd.string-field` was wrong in the mobile UI of `create-site` page. The action should take in a `ftd.string-field` and the `on-click` should provide the whole `ftd.string-field` for error handling.

This is fixed now.