### PR TITLE
Fix: `update-preview` cmd shouldn't be completed with current file

### DIFF
--- a/components/editor/command-k/index.ftd
+++ b/components/editor/command-k/index.ftd
@@ -131,7 +131,7 @@ $on-click$: $vars.open-command-k-with-current-file(cmd=delete-file)
 $on-click$: $vars.open-command-k-with-current-file(cmd=push-file)
 
 -- ftd.text: `update-preview` (Update the preview panel)
-$on-click$: $vars.open-command-k-with-current-file(cmd=update-preview)
+$on-click$: $vars.open-command-k(cmd=update-preview)
 
 -- end: ftd.column
 


### PR DESCRIPTION
Clicking on `update-preview` from the list of "Available commands"
autocompletes it with the current file. This makes the command invalid
as it does not accept any filepath. This is fixed now.
