### PR TITLE
Change default preview from todayhasbeen to editor-preview

### DIFF
--- a/components/editor/vars.ftd
+++ b/components/editor/vars.ftd
@@ -166,7 +166,8 @@ url: /foo/blog/images/first-image.jpg
 
 -- boolean $preview-visible: true
 
--- string $preview-url: https://todayhasbeen.com
+;; edit the content here: https://www.fifthtry.com/ide/editor-preview/index.ftd
+-- string $preview-url: https://editor-preview.fifthtry.site/
 
 -- main-editor.doc $doc:
 file-name: FASTN.ftd


### PR DESCRIPTION
The default preview url is changed from https://todayhasbeen.com to
https://editor-preview.fifthtry.site/.

The source of the preview can be changed at https://www.fifthtry.com/ide/editor-preview/index.ftd
